### PR TITLE
Add jgz extension to gzipped files

### DIFF
--- a/public_website/templates/index.html
+++ b/public_website/templates/index.html
@@ -24,7 +24,7 @@
   {% if debug %}
     {% render_bundle 'public_website' 'js' %}
   {% else %}
-    {% render_bundle 'public_website' 'js.gz' %}
+    {% render_bundle 'public_website' 'js.jgz' %}
   {% endif %}
 
 </body>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ daphne==1.3.0
 dj-database-url==0.4.2
 Django==1.11.7
 django-extensions==1.9.8
-django-webpack-loader==0.5.0
+-e git+git@github.com:Verbozeteam/django-webpack-loader.git@14e12cf118c6ee381702603a416b37deedf59215#egg=django_webpack_loader
 djangorestframework==3.7.3
 gunicorn==19.7.1
 hyperlink==17.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ daphne==1.3.0
 dj-database-url==0.4.2
 Django==1.11.7
 django-extensions==1.9.8
--e git+git@github.com:Verbozeteam/django-webpack-loader.git@14e12cf118c6ee381702603a416b37deedf59215#egg=django_webpack_loader
+-e git+git@github.com:Verbozeteam/django-webpack-loader.git@master#egg=django_webpack_loader
 djangorestframework==3.7.3
 gunicorn==19.7.1
 hyperlink==17.3.1

--- a/verboze/whitenoise_utils.py
+++ b/verboze/whitenoise_utils.py
@@ -1,4 +1,4 @@
 
 def add_gzip_encoding(headers, path, url):
-	if path.endswith('.gz'):
+	if path.endswith('.jgz'):
 		headers['Content-Encoding'] = 'gzip'

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -16,7 +16,7 @@ module.exports = WebpackMerge(common, {
             'process.env.NODE_ENV': JSON.stringify('production')
         }),
         new CompressionPlugin({
-            asset: "[path].gz[query]",
+            asset: "[path].jgz[query]",
             algorithm: "gzip",
             test: /\.js$/,
             threshold: 10240,


### PR DESCRIPTION
Safari doesnt like .gz files for some reason, but likes .jgz for gzipped files